### PR TITLE
fix: 뿌리기 정보 조회 API 응답에 뿌리기 등록 여부 필드 추가

### DIFF
--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleService.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleService.kt
@@ -16,8 +16,8 @@ import mashup.ggiriggiri.gifticonstorm.domain.participant.repository.Participant
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.domain.OrderBy
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.domain.Sprinkle
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.dto.GetSprinkleResDto
-import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.dto.SprinkleRegistHistoryResDto
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.dto.SprinkleInfoResDto
+import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.dto.SprinkleRegistHistoryResDto
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.repository.SprinkleRepository
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.SprinkleInfoVo
 import org.springframework.data.repository.findByIdOrNull
@@ -88,10 +88,11 @@ class SprinkleService(
 
         participantRepository.save(Participant(applySprinkleMember, sprinkle))
     }
-    fun getSprinkleInfo(sprinkleId: Long): SprinkleInfoResDto {
+
+    fun getSprinkleInfo(sprinkleId: Long, userInfoDto: UserInfoDto): SprinkleInfoResDto {
         val sprinkleInfoVo = sprinkleRepository.findInfoById(sprinkleId)
             ?: throw EntityNotFoundException("sprinkle", "sprinkleId : $sprinkleId")
-        return SprinkleInfoResDto.of(sprinkleInfoVo)
+        return SprinkleInfoResDto.of(sprinkleInfoVo, userInfoDto)
     }
 
     fun getSprinkleRegistHistory(userInfoDto: UserInfoDto, noOffsetRequest: NoOffsetRequest): List<SprinkleRegistHistoryResDto> {

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/dto/SprinkleInfoResDto.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/dto/SprinkleInfoResDto.kt
@@ -1,5 +1,6 @@
 package mashup.ggiriggiri.gifticonstorm.domain.sprinkle.dto
 
+import mashup.ggiriggiri.gifticonstorm.config.resolver.UserInfoDto
 import mashup.ggiriggiri.gifticonstorm.domain.coupon.domain.Category
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.SprinkleInfoVo
 
@@ -10,11 +11,12 @@ data class SprinkleInfoResDto(
     val category: Category,
     val expiredAt: String,
     val participants: Int,
-    val sprinkleAt: String
+    val sprinkleAt: String,
+    val registeredBy: Boolean
 ) {
 
     companion object {
-        fun of(sprinkleInfoVo: SprinkleInfoVo): SprinkleInfoResDto {
+        fun of(sprinkleInfoVo: SprinkleInfoVo, userInfoDto: UserInfoDto): SprinkleInfoResDto {
             return SprinkleInfoResDto(
                 sprinkleId = sprinkleInfoVo.sprinkleId,
                 brandName = sprinkleInfoVo.brandName,
@@ -22,7 +24,8 @@ data class SprinkleInfoResDto(
                 category = sprinkleInfoVo.category,
                 expiredAt = sprinkleInfoVo.expiredAt.toString(),
                 participants = sprinkleInfoVo.participants,
-                sprinkleAt = sprinkleInfoVo.sprinkleAt.toString()
+                sprinkleAt = sprinkleInfoVo.sprinkleAt.toString(),
+                registeredBy = sprinkleInfoVo.getRegisteredBy(userInfoDto)
             )
         }
     }

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/repository/SprinkleRepositoryCustomImpl.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/repository/SprinkleRepositoryCustomImpl.kt
@@ -7,8 +7,8 @@ import mashup.ggiriggiri.gifticonstorm.domain.coupon.domain.Category
 import mashup.ggiriggiri.gifticonstorm.domain.coupon.domain.QCoupon.coupon
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.domain.QSprinkle.sprinkle
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.QSprinkleInfoVo
-import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.SprinkleInfoVo
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.QSprinkleRegistHistoryVo
+import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.SprinkleInfoVo
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo.SprinkleRegistHistoryVo
 import java.time.LocalDateTime
 import java.util.stream.Collectors
@@ -27,7 +27,8 @@ class SprinkleRepositoryCustomImpl(
                 coupon.category,
                 coupon.expiredAt,
                 sprinkle.participants.size(),
-                sprinkle.sprinkleAt
+                sprinkle.sprinkleAt,
+                sprinkle.member.id
             ))
             .from(sprinkle)
             .join(sprinkle.coupon, coupon)
@@ -46,7 +47,8 @@ class SprinkleRepositoryCustomImpl(
                 coupon.category,
                 coupon.expiredAt,
                 sprinkle.participants.size(),
-                sprinkle.sprinkleAt
+                sprinkle.sprinkleAt,
+                sprinkle.member.id
             ))
             .from(sprinkle)
             .join(sprinkle.coupon, coupon)
@@ -63,13 +65,14 @@ class SprinkleRepositoryCustomImpl(
     override fun findInfoById(id: Long): SprinkleInfoVo? {
         return jpaQueryFactory
             .select(QSprinkleInfoVo(
-                    sprinkle.id,
-                    coupon.brandName,
-                    coupon.merchandiseName,
-                    coupon.category,
-                    coupon.expiredAt,
-                    sprinkle.participants.size(),
-                    sprinkle.sprinkleAt
+                sprinkle.id,
+                coupon.brandName,
+                coupon.merchandiseName,
+                coupon.category,
+                coupon.expiredAt,
+                sprinkle.participants.size(),
+                sprinkle.sprinkleAt,
+                sprinkle.member.id
             ))
             .from(sprinkle)
             .join(sprinkle.coupon, coupon)

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/vo/SprinkleInfoVo.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/vo/SprinkleInfoVo.kt
@@ -1,6 +1,7 @@
 package mashup.ggiriggiri.gifticonstorm.domain.sprinkle.vo
 
 import com.querydsl.core.annotations.QueryProjection
+import mashup.ggiriggiri.gifticonstorm.config.resolver.UserInfoDto
 import mashup.ggiriggiri.gifticonstorm.domain.coupon.domain.Category
 import java.time.LocalDateTime
 
@@ -11,5 +12,11 @@ data class SprinkleInfoVo @QueryProjection constructor(
     val category: Category,
     val expiredAt: LocalDateTime,
     val participants: Int,
-    val sprinkleAt: LocalDateTime
-)
+    val sprinkleAt: LocalDateTime,
+    val memberId : Long
+) {
+
+    fun getRegisteredBy(userInfoDto: UserInfoDto): Boolean {
+        return memberId == userInfoDto.id
+    }
+}

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/presentation/SprinkleController.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/presentation/SprinkleController.kt
@@ -60,7 +60,7 @@ class SprinkleController(
         @UserInfo userInfoDto: UserInfoDto,
         @PathVariable(name = "id") sprinkleId: Long
     ): BaseResponse<SprinkleInfoResDto> {
-        return BaseResponse.ok(sprinkleService.getSprinkleInfo(sprinkleId))
+        return BaseResponse.ok(sprinkleService.getSprinkleInfo(sprinkleId, userInfoDto))
     }
 
     @GetMapping("/sprinkle/registration-history")

--- a/src/test/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleServiceTest.kt
+++ b/src/test/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleServiceTest.kt
@@ -107,11 +107,10 @@ internal class SprinkleServiceTest : FunSpec({
     context("뿌리기 정보 조회") {
         test("성공") {
             //given
-            every { sprinkleRepository.findByIdOrNull(1) } returns sprinkle
             every { sprinkleRepository.findInfoById(1) } returns sprinkleInfoVos[0]
 
             //when
-            val resDto = sprinkleService.getSprinkleInfo(1)
+            val resDto = sprinkleService.getSprinkleInfo(1, userInfoDto)
 
             //then
             resDto.sprinkleId shouldBe 1
@@ -121,13 +120,14 @@ internal class SprinkleServiceTest : FunSpec({
             resDto.expiredAt shouldBe now.plusDays(1).with(LocalTime.MAX).toString()
             resDto.participants shouldBe 3
             resDto.sprinkleAt shouldBe now.plusMinutes(10).toString()
+            resDto.registeredBy shouldBe true
         }
 
         test("실패 - 해당 뿌리기가 존재하지 않을 때") {
             every { sprinkleRepository.findInfoById(1) } returns null
 
             shouldThrow<BaseException> {
-                sprinkleService.getSprinkleInfo(1)
+                sprinkleService.getSprinkleInfo(1, userInfoDto)
             }
         }
     }
@@ -163,7 +163,8 @@ internal class SprinkleServiceTest : FunSpec({
                 category = Category.CAFE,
                 expiredAt = now.plusDays(1).with(LocalTime.MAX),
                 participants = 3,
-                sprinkleAt = now.plusMinutes(10)
+                sprinkleAt = now.plusMinutes(10),
+                memberId = 1
             ),
             SprinkleInfoVo(
                 sprinkleId = 2,
@@ -172,7 +173,8 @@ internal class SprinkleServiceTest : FunSpec({
                 category = Category.ICECREAM,
                 expiredAt = now.plusDays(1).with(LocalTime.MAX),
                 participants = 2,
-                sprinkleAt = now.plusMinutes(9)
+                sprinkleAt = now.plusMinutes(9),
+                memberId = 2
             )
         )
 

--- a/src/test/kotlin/mashup/ggiriggiri/gifticonstorm/presentation/SprinkleControllerTest.kt
+++ b/src/test/kotlin/mashup/ggiriggiri/gifticonstorm/presentation/SprinkleControllerTest.kt
@@ -593,10 +593,11 @@ internal class SprinkleControllerTest : TestRestDocs() {
             category = Category.CAFE,
             expiredAt = now.plusDays(1).with(LocalTime.MAX).toString(),
             sprinkleAt = now.plusMinutes(10).toString(),
-            participants = 100
+            participants = 100,
+            registeredBy = false
         )
 
-        every { sprinkleService.getSprinkleInfo(1) } returns resDto
+        every { sprinkleService.getSprinkleInfo(1, userInfoDto) } returns resDto
 
         //when, then
         mockMvc.perform(
@@ -615,7 +616,7 @@ internal class SprinkleControllerTest : TestRestDocs() {
             )
             .andDo(
                 MockMvcRestDocumentation.document(
-                    "뿌리기 단건 조회/{methodName}",
+                    "뿌리기 정보 조회/{methodName}",
                     HeaderDocumentation.requestHeaders(
                         HeaderDocumentation.headerWithName("Authorization").description("애플 사용자 고유 id"),
                     ),
@@ -632,6 +633,7 @@ internal class SprinkleControllerTest : TestRestDocs() {
                         PayloadDocumentation.fieldWithPath("data.expiredAt").type(JsonFieldType.STRING).description("유효기간"),
                         PayloadDocumentation.fieldWithPath("data.sprinkleAt").type(JsonFieldType.STRING).description("뿌리기 시간"),
                         PayloadDocumentation.fieldWithPath("data.participants").type(JsonFieldType.NUMBER).description("응모자 수"),
+                        PayloadDocumentation.fieldWithPath("data.registeredBy").type(JsonFieldType.BOOLEAN).description("자신이 등록한 뿌리기 여부"),
                     ),
                     HeaderDocumentation.requestHeaders()
                 )


### PR DESCRIPTION
- 뿌리기 정보 조회 API 응답에 뿌리기 등록 여부 필드 추가했습니다.

### Related Issue
resolve #59 