### PR TITLE
feat: 이미지 크기 3MB로 제한 및 에러처리 구체화

### DIFF
--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/common/dto/ResponseCode.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/common/dto/ResponseCode.kt
@@ -21,6 +21,8 @@ enum class ResponseCode(
     ALREADY_PARTICIPATE_IN(HttpStatus.BAD_REQUEST, "F006", "이미 응모한 뿌리기 입니다."),
     ALREADY_EXPIRED_SPRINKLE(HttpStatus.BAD_REQUEST, "F007", "이미 만료된 뿌리기 입니다."),
 
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "F008", "HTTP PAYLOAD가 너무 큽니다."),
+
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "유효하지 않은 입력값 입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 에러가 발생했습니다.")

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/common/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/common/error/GlobalExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -52,5 +53,12 @@ class GlobalExceptionHandler {
     private fun handMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): BaseResponse<Unit> {
         log.warn(e.message, e)
         return BaseResponse.error(ResponseCode.INVALID_INPUT_VALUE)
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException::class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    private fun handlePayloadTooLarge(e : MaxUploadSizeExceededException) : BaseResponse<Unit> {
+        log.error(e.message, e)
+        return BaseResponse.error(ResponseCode.PAYLOAD_TOO_LARGE)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   profiles:
     include: db, aws, ocr, discord, log
     active: local
+  servlet:
+    multipart:
+      max-file-size: 3MB
+      max-request-size: 4MB
 
 server:
   error:


### PR DESCRIPTION
Tomcat이 받을 수 있는 파일 사이즈를 3MB로 늘렸습니다.
에러처리도 구체화했어요