### PR TITLE
fix: UserInfoResolver의 새로운 사용자 등록 부분 수정

### DIFF
--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/config/resolver/UserInfoResolver.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/config/resolver/UserInfoResolver.kt
@@ -38,8 +38,7 @@ class UserInfoResolver(
             return UserInfoDto(id = it.id, inherenceId = it.inherenceId)
         }
 
-
-        return memberRepository.save(Member(inherenceId =  authkey)).also {
+        return memberRepository.save(Member(inherenceId =  authkey)).let {
             log.info("GOGOGO")
             signinBot.notify(it.id)
             UserInfoDto(id = it.id, inherenceId = it.inherenceId)


### PR DESCRIPTION
### 이슈 상황
- 새로운 Authorization Header 값으로 첫 요청을 보낼 때 500 Internal Server Error가 발생한다.

### 이슈 원인
- 새로운 Authorization Header 값으로 Member를 저장한 뒤, UserInfoDto 객체를 반환해야 하는데, Member 객체가 반환되어 `java.lang.IllegalArgumentException: java.lang.ClassCastException`이 발생하였다.