### PR TITLE
fix: 뿌리기 대상 조회 쿼리 수정

### DIFF
--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleDrawHandler.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/application/sprinkle/SprinkleDrawHandler.kt
@@ -5,6 +5,7 @@ import mashup.ggiriggiri.gifticonstorm.infrastructure.Logger
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Component
 class SprinkleDrawHandler(
@@ -16,7 +17,7 @@ class SprinkleDrawHandler(
     @Transactional
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     fun drawEventListener() {
-        val sprinkles = sprinkleRepository.findAllBySprinkledFalse()
+        val sprinkles = sprinkleRepository.findAllBySprinkledFalseAndSprinkleAtLessThanEqual(LocalDateTime.now())
         if (sprinkles.isEmpty()) {
             log.info("[DRAW] no sprinkles")
             return

--- a/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/repository/SprinkleRepository.kt
+++ b/src/main/kotlin/mashup/ggiriggiri/gifticonstorm/domain/sprinkle/repository/SprinkleRepository.kt
@@ -2,7 +2,9 @@ package mashup.ggiriggiri.gifticonstorm.domain.sprinkle.repository
 
 import mashup.ggiriggiri.gifticonstorm.domain.sprinkle.domain.Sprinkle
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 
 interface SprinkleRepository: JpaRepository<Sprinkle, Long>, SprinkleRepositoryCustom {
-    fun findAllBySprinkledFalse() : List<Sprinkle>
+
+    fun findAllBySprinkledFalseAndSprinkleAtLessThanEqual(time: LocalDateTime): List<Sprinkle>
 }


### PR DESCRIPTION
### 수정사항
- sprinkled가 false이고, sprinkleAt이 현재 시간과 같거나 이전인 뿌리기 데이터 조회